### PR TITLE
Split bert into lib+bin, relocate ECS type aliases (#42)

### DIFF
--- a/src/bevy_app/mod.rs
+++ b/src/bevy_app/mod.rs
@@ -10,10 +10,6 @@ mod states;
 mod systems;
 mod utils;
 
-use crate::{
-    ExternalEntityFilter, ExternalEntityQuery, InteractionQuery, InterfaceQuery, IsSameAsIdQuery,
-    SelectionFilter, SubSystemQuery, SystemQuery,
-};
 use bevy::asset::AssetMetaCheck;
 use bevy::input::common_conditions::input_just_pressed;
 use bevy::input::common_conditions::input_pressed;
@@ -30,6 +26,22 @@ use data_model::load::load_world;
 use data_model::save::{save_world, save_world_as, serialize_world};
 pub use events::*;
 use leptos_bevy_canvas::prelude::*;
+
+/// Bevy ECS query and filter type aliases used by UI bridge code (Leptos-side)
+/// and by internal Bevy systems. Defined here because they compose types from
+/// this module (`components::*`) and standard Bevy primitives — no dependency
+/// on Leptos. Moved from `leptos_app/mod.rs` where they were defined next to
+/// their first consumer but couldn't cleanly separate from bevy_app.
+pub type InterfaceQuery = (Name, ElementDescription, Interface);
+pub type InteractionQuery = (Name, ElementDescription, Flow);
+pub type ExternalEntityQuery = (Name, ElementDescription, ExternalEntity);
+// `components::System` disambiguates from `bevy::prelude::System` (the trait).
+pub type SystemQuery = (Name, ElementDescription, components::System, SystemEnvironment);
+pub type SubSystemQuery = (Name, ElementDescription, components::System, ParentState);
+pub type IsSameAsIdQuery = (IsSameAsId,);
+pub type SelectionFilter = With<SelectedHighlightHelperAdded>;
+pub type SubSystemFilter = With<Subsystem>;
+pub type ExternalEntityFilter = With<ExternalEntity>;
 use plugins::label::{
     copy_position, copy_positions, copy_positions_changed, LabelPlugin, MarkerLabel, NameLabel,
 };

--- a/src/leptos_app/mod.rs
+++ b/src/leptos_app/mod.rs
@@ -7,8 +7,7 @@ mod use_file_dialog;
 use crate::bevy_app::data_model::complexity_calculator::calculate_simonian_complexity;
 use crate::bevy_app::init_bevy_app;
 use crate::bevy_app::{
-    components::System, DetachMarkerLabelEvent, ElementDescription, ExternalEntity, Flow,
-    Interface, IsSameAsId, SelectedHighlightHelperAdded, SystemElement, SystemEnvironment,
+    DetachMarkerLabelEvent, SelectedHighlightHelperAdded, SystemElement,
 };
 use crate::bevy_app::{
     ExternalEntityFilter, ExternalEntityQuery, InteractionQuery, InterfaceQuery, IsSameAsIdQuery,
@@ -16,7 +15,7 @@ use crate::bevy_app::{
 };
 use crate::leptos_app::components::{ControlsMenu, ModelBrowser, Palette, Toast};
 use crate::leptos_app::details::Details;
-use crate::{LoadFileEvent, ParentState, Subsystem};
+use crate::LoadFileEvent;
 use bevy::prelude::With;
 use leptos::prelude::*;
 use leptos_bevy_canvas::prelude::{

--- a/src/leptos_app/mod.rs
+++ b/src/leptos_app/mod.rs
@@ -10,11 +10,14 @@ use crate::bevy_app::{
     components::System, DetachMarkerLabelEvent, ElementDescription, ExternalEntity, Flow,
     Interface, IsSameAsId, SelectedHighlightHelperAdded, SystemElement, SystemEnvironment,
 };
+use crate::bevy_app::{
+    ExternalEntityFilter, ExternalEntityQuery, InteractionQuery, InterfaceQuery, IsSameAsIdQuery,
+    SelectionFilter, SubSystemFilter, SubSystemQuery, SystemQuery,
+};
 use crate::leptos_app::components::{ControlsMenu, ModelBrowser, Palette, Toast};
 use crate::leptos_app::details::Details;
-use crate::LoadFileEvent;
-use crate::{ParentState, Subsystem};
-use bevy::prelude::{Name, With};
+use crate::{LoadFileEvent, ParentState, Subsystem};
+use bevy::prelude::With;
 use leptos::prelude::*;
 use leptos_bevy_canvas::prelude::{
     message_b2l, message_l2b, signal_synced, single_query_signal, BevyCanvas,
@@ -22,17 +25,6 @@ use leptos_bevy_canvas::prelude::{
 use leptos_meta::*;
 use use_file_dialog::use_file_dialog_with_options;
 
-pub type InterfaceQuery = (Name, ElementDescription, Interface);
-pub type InteractionQuery = (Name, ElementDescription, Flow);
-pub type ExternalEntityQuery = (Name, ElementDescription, ExternalEntity);
-pub type SystemQuery = (Name, ElementDescription, System, SystemEnvironment);
-pub type SubSystemQuery = (Name, ElementDescription, System, ParentState);
-
-pub type IsSameAsIdQuery = (IsSameAsId,);
-
-pub type SelectionFilter = With<SelectedHighlightHelperAdded>;
-pub type SubSystemFilter = With<Subsystem>;
-pub type ExternalEntityFilter = With<ExternalEntity>;
 use crate::events::{
     CancelModeEvent, DeselectAllEvent, ModeChangeEvent, PaletteClickEvent, SaveSuccessEvent,
     TreeEvent, TriggerEvent, ZoomEvent,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,9 @@
+#![feature(string_remove_matches)]
+#![allow(clippy::all)]
+#![allow(dead_code)]
+
+pub mod bevy_app;
+pub mod leptos_app;
+
+pub use bevy_app::*;
+pub use leptos_app::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,8 @@
 #![allow(clippy::all)]
 #![allow(dead_code)]
 
-pub mod bevy_app;
-pub mod leptos_app;
-
-pub use bevy_app::*;
+use bert::App;
 use leptos::mount;
-pub use leptos_app::*;
 
 fn main() {
     console_error_panic_hook::set_once();

--- a/tests/native_import.rs
+++ b/tests/native_import.rs
@@ -1,0 +1,33 @@
+//! Regression test: ensures external native Rust crates can import and use
+//! `bert::bevy_app::data_model::WorldModel` for JSON deserialization.
+//!
+//! This test guards the lib+bin split introduced in issue #42. It is run
+//! on the default (native) cargo target, exercising the native compile path
+//! for the bert library — distinct from the WASM path exercised by
+//! `cargo check --target wasm32-unknown-unknown`.
+//!
+//! Downstream consumers (e.g. the BERT→TypeDB transpiler, #37) depend on
+//! being able to read a BERT JSON model natively without pulling in a full
+//! Bevy App. If this test ever fails, investigate the lib crate structure
+//! before modifying the test.
+
+use bert::bevy_app::data_model::WorldModel;
+
+#[test]
+fn bitcoin_json_deserializes_as_worldmodel() {
+    let path = "assets/models/examples/bitcoin.json";
+    let bytes = std::fs::read(path).expect("bitcoin.json should exist");
+    let model: WorldModel =
+        serde_json::from_slice(&bytes).expect("bitcoin.json should deserialize");
+
+    // Smoke: some plausible sizes so a silent empty parse doesn't pass.
+    assert!(
+        !model.systems.is_empty(),
+        "WorldModel.systems should not be empty"
+    );
+    assert!(
+        !model.interactions.is_empty(),
+        "WorldModel.interactions should not be empty"
+    );
+    assert_eq!(model.version, 1);
+}


### PR DESCRIPTION
## Summary

Closes #42. Two commits that structurally enable native Rust crates (notably the forthcoming BERT→TypeDB transpiler from #37) to consume BERT's data model.

## What changed

**Commit 1 (`d90bec2`)** — structural foundation:
- Add `src/lib.rs` exposing `bevy_app` and `leptos_app` as library modules. Simplify `src/main.rs` to a thin shell that calls `bert::App`.
- Move 9 ECS type aliases (`SystemQuery`, `ExternalEntityFilter`, etc.) from `src/leptos_app/mod.rs` → `src/bevy_app/mod.rs`. These were Bevy `Query`/`Filter` types composing ECS components — no Leptos-specific content — that had drifted to the Leptos side because that's where `leptos-bevy-canvas` bridge code first consumed them. Putting them in `bevy_app` matches their actual semantics and removes a weird use-cycle (`bevy_app` had been importing them back from crate root via `pub use leptos_app::*`).
- Disambiguate `components::System` from `bevy::prelude::System` (the trait) in `SystemQuery` and `SubSystemQuery`.

**Commit 2 (`1082a81`)** — polish:
- Remove unused imports from `leptos_app/mod.rs` left over from the type alias relocation.
- Add `tests/native_import.rs` as a regression guard: deserializes `bitcoin.json` as `WorldModel` via pure library import. Exercises the native compile path.

## Discovery

Mid-refactor experiment (`/tmp/bert-native-probe`) revealed that WASM-specific dependencies (`wasm-bindgen`, `js-sys`, `web-sys`, `tauri-sys`) **compile cleanly on native targets with no-op fallbacks**. The initially-planned `gui` feature flag to gate these deps turned out to be unnecessary. See session notes at `operations/sessions/2026-04-19/bert-schema-typedb-foundation.md` and research reference at `operations/sessions/2026-04-19/typedb-transpiler-research-reference.md`.

This shrank #42's scope substantially — from "lib+bin split + gui feature + optional deps + module gating" to just "lib+bin split + type alias relocation."

## Verification

- `cargo check` (native): clean
- `cargo check --target wasm32-unknown-unknown`: clean
- `trunk build`: clean (full WASM bundle produced successfully)
- `cargo test --test native_import`: passes
- Compile time for external native consumer: ~56s cold build (full BERT deps). Acceptable for a one-time build; future optimization via feature flags possible if binary size or compile time become pain points.

## Unblocks

- #37 (BERT→TypeDB transpiler) — can now depend on `bert` as a library and import `WorldModel`
- Any future native Rust consumer of BERT's data model

## Future work (not in this PR)

A `gui` feature flag could later be added to shrink compile time and binary size for external consumers. Not urgent — ship the transpiler first, optimize if it becomes a pain point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)