### PR TITLE
chore(typedb): migrate typedb-driver 3.8 → 3.11.5

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1"
 tauri-plugin-dialog = "2.3"
 tauri-plugin-fs = "2.4"
 leptos = { version = "0.8", features = ["csr"] }
-typedb-driver = "3.8"
+typedb-driver = "3.11.5"
 uuid = { version = "1", features = ["v4"] }
 tokio = { version = "1", features = ["process", "io-util"] }
 futures = "0.3"

--- a/src-tauri/src/typedb_reader.rs
+++ b/src-tauri/src/typedb_reader.rs
@@ -1,15 +1,19 @@
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
-use typedb_driver::{Credentials, DriverOptions, TransactionType, TypeDBDriver};
+use typedb_driver::{
+    Addresses, Credentials, DriverOptions, DriverTlsConfig, TransactionType, TypeDBDriver,
+};
 
 const DEFAULT_HOST: &str = "localhost:1729";
 const DEFAULT_USERNAME: &str = "admin";
 const DEFAULT_PASSWORD: &str = "password";
 
 pub async fn connect() -> Result<TypeDBDriver, String> {
-    let opts = DriverOptions::new(false, None).map_err(|e| format!("DriverOptions: {e}"))?;
+    let opts = DriverOptions::new(DriverTlsConfig::disabled());
+    let addresses =
+        Addresses::try_from_address_str(DEFAULT_HOST).map_err(|e| format!("Addresses: {e}"))?;
     TypeDBDriver::new(
-        DEFAULT_HOST,
+        addresses,
         Credentials::new(DEFAULT_USERNAME, DEFAULT_PASSWORD),
         opts,
     )

--- a/tools/bert-typedb/Cargo.toml
+++ b/tools/bert-typedb/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 bert = { path = "../.." }
-typedb-driver = "3.8"
+typedb-driver = "3.11.5"
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 clap = { version = "4", features = ["derive"] }

--- a/tools/bert-typedb/src/driver.rs
+++ b/tools/bert-typedb/src/driver.rs
@@ -20,7 +20,9 @@
 use crate::error::TranspilerError;
 use crate::schema::SCHEMA_TQL;
 use std::time::{Duration, Instant};
-use typedb_driver::{Credentials, DriverOptions, TransactionType, TypeDBDriver};
+use typedb_driver::{
+    Addresses, Credentials, DriverOptions, DriverTlsConfig, TransactionType, TypeDBDriver,
+};
 
 /// Default local TypeDB server address.
 pub const DEFAULT_ADDRESS: &str = "localhost:1729";
@@ -57,10 +59,14 @@ impl Transpiler {
         username: &str,
         password: &str,
     ) -> Result<Self, TranspilerError> {
-        let driver_opts = DriverOptions::new(false, None).map_err(|e| {
-            TranspilerError::Internal(format!("DriverOptions construction failed: {e}"))
+        let driver_opts = DriverOptions::new(DriverTlsConfig::disabled());
+        let addresses = Addresses::try_from_address_str(host).map_err(|e| {
+            TranspilerError::Connection {
+                host: host.to_string(),
+                source: Box::new(e),
+            }
         })?;
-        let driver = TypeDBDriver::new(host, Credentials::new(username, password), driver_opts)
+        let driver = TypeDBDriver::new(addresses, Credentials::new(username, password), driver_opts)
             .await
             .map_err(|e| TranspilerError::Connection {
                 host: host.to_string(),

--- a/tools/bert-typedb/src/driver.rs
+++ b/tools/bert-typedb/src/driver.rs
@@ -60,18 +60,18 @@ impl Transpiler {
         password: &str,
     ) -> Result<Self, TranspilerError> {
         let driver_opts = DriverOptions::new(DriverTlsConfig::disabled());
-        let addresses = Addresses::try_from_address_str(host).map_err(|e| {
-            TranspilerError::Connection {
-                host: host.to_string(),
-                source: Box::new(e),
-            }
-        })?;
-        let driver = TypeDBDriver::new(addresses, Credentials::new(username, password), driver_opts)
-            .await
-            .map_err(|e| TranspilerError::Connection {
+        let addresses =
+            Addresses::try_from_address_str(host).map_err(|e| TranspilerError::Connection {
                 host: host.to_string(),
                 source: Box::new(e),
             })?;
+        let driver =
+            TypeDBDriver::new(addresses, Credentials::new(username, password), driver_opts)
+                .await
+                .map_err(|e| TranspilerError::Connection {
+                    host: host.to_string(),
+                    source: Box::new(e),
+                })?;
         Ok(Self {
             driver,
             db_name: db_name.to_string(),

--- a/tools/bert-typedb/src/insert.rs
+++ b/tools/bert-typedb/src/insert.rs
@@ -483,6 +483,7 @@ fn process_primitive_str(p: ProcessPrimitive) -> &'static str {
         ProcessPrimitive::Copying => "Copying",
         ProcessPrimitive::Sensing => "Sensing",
         ProcessPrimitive::Modulating => "Modulating",
+        ProcessPrimitive::Amplifying => "Amplifying",
         ProcessPrimitive::Inverting => "Inverting",
     }
 }


### PR DESCRIPTION
Unblocks the workspace build / release path (#96). The 3.8 → 3.11.5 driver bump is an API break; this migrates both call sites.

## Changes

- **`DriverOptions::new(bool, Option<_>)` → `DriverOptions::new(DriverTlsConfig::disabled())`** (no longer fallible).
- **`TypeDBDriver::new(&str, …)` → takes `Addresses`** via `Addresses::try_from_address_str(host)`.
- Both call sites migrated: `src-tauri/src/typedb_reader.rs::connect()` and `tools/bert-typedb/src/driver.rs::Transpiler::connect()`.
- `insert.rs`: adds the `ProcessPrimitive::Amplifying` match arm so the tool stays exhaustive against the current bert-core enum (the `"Amplifying"` string already exists in `schema.tql` — three-way consistent).

## Why this was parked

It was finished-but-uncommitted local WIP, set aside during bert#88 so the kernel diff stayed clean (the TypeDB path isn't on the critical path — sims run without it). Now landed on its own so it's reviewed/CI'd independently.

## Verification

- `cargo check --workspace` clean (previously red on `main` — this is the fix).
- bert-typedb default suite passes.
- **Integration smoke test passes against a live TypeDB 3.11.5**: `cargo test -p bert-typedb --features integration --test driver_smoke` → `connect_and_roundtrip_schema` (connect → create db → roundtrip schema → drop) + `schema_constant_is_nonempty`, 2/2.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)